### PR TITLE
#4714: aggregate published files by task name (instead of id) 

### DIFF
--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -481,12 +481,10 @@ class SgLatestPublishModel(ShotgunModel):
                 
         # also, if there are cases where there are two items with the same name and the same type, 
         # but with different tasks, indicate this with a special boolean flag
-                
         unique_data = {}
         name_type_aggregates = defaultdict(int)
         
         for sg_item in sg_data_list:
-            
             # get the associated type
             type_id = None
             type_link = sg_item[self._publish_type_field]
@@ -497,7 +495,9 @@ class SgLatestPublishModel(ShotgunModel):
             task_id = None
             task_link = sg_item["task"]
             if task_link:
-                task_id = task_link["id"]  
+                # check uniqueness of task by name, not id
+                # i.e. collapse publish files associated with tasks which have same name as well
+                task_id = task_link["name"]
 
             # key publishes in dict by type and name
             unique_data[ (sg_item["name"], type_id, task_id) ] = {"sg_item": sg_item, "type_id": type_id}
@@ -514,7 +514,6 @@ class SgLatestPublishModel(ShotgunModel):
 
             # get the shotgun data for this guy
             sg_item = second_pass_data["sg_item"]
-            
             # now add a flag to indicate if this item is "task unique" or not
             # e.g. if there are other items in the listing with the same name 
             # and same type but with a different task

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -65,10 +65,10 @@ class SgPublishHistoryModel(ShotgunModel):
         # when we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
         # which have the same project, same entity assocation, same name, same type 
-        # and the same task.
+        # and the same task name.
         filters = [ ["project", "is", sg_data["project"] ],
                     ["name", "is", sg_data["name"] ],
-                    ["task", "is", sg_data["task"] ],
+                    ["task", "name_is", sg_data["task"]["name"] ],
                     ["entity", "is", sg_data["entity"] ],
                     [publish_type_field, "is", sg_data[publish_type_field] ],
                   ]


### PR DESCRIPTION
Search for publish history using the task name as well.
This is required as same task is carried out by multiple artists and having separate tasks helps prod to track time better on shotgun.